### PR TITLE
FIX. Avoid error with date arg in docker-build

### DIFF
--- a/.github/workflows/gke-docker-build.yml
+++ b/.github/workflows/gke-docker-build.yml
@@ -109,7 +109,7 @@ jobs:
           DOCKER_BUILDKIT=1 docker build -t ${IMAGE}:${TAG} -f ${PWD}/${DOCKERFILE} \
           --build-arg REGISTRY=${REGISTRY} \
           --build-arg TAG=${TAG} \
-          --build-arg BUILD_TIMESTAMP=${{steps.update_version_and_deploy_files.outputs.build_timestamp}} \
+          --build-arg BUILD_TIMESTAMP="${{steps.update_version_and_deploy_files.outputs.build_timestamp}}" \
           --build-arg IMAGE=${IMAGE} .
           echo "::debug ::Docker image is tagged with ${IMAGE}:${TAG}"
 
@@ -122,7 +122,7 @@ jobs:
           DOCKER_BUILDKIT=1 docker build -t ${IMAGE}:${TAG} -f ${PWD}/${DOCKERFILE} \
           --build-arg REGISTRY=${REGISTRY} \
           --build-arg TAG=${TAG} \
-          --build-arg BUILD_TIMESTAMP=${{steps.update_version_and_deploy_files.outputs.build_timestamp}} \
+          --build-arg BUILD_TIMESTAMP="${{steps.update_version_and_deploy_files.outputs.build_timestamp}}" \
           --build-arg IMAGE=${IMAGE} \
           --secret id=github-access-token,src=secret-github-access-token.txt .
           echo "::debug ::Docker image is tagged with ${IMAGE}:${TAG}"


### PR DESCRIPTION
Error already [fixed](https://github.com/alice-biometrics/onboarding-rest/commit/860fcf9d93c9df8a0f279d129c4ffc77d0581ccb) in legacy workflows